### PR TITLE
v2.2.0 develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,43 @@ Check if you can download the ics file you have designated in the block with a b
 
  Yes you can,  I have tested this with [https://p24-calendars.icloud.com/holiday/NL_nl.ics](https://p24-calendars.icloud.com/holiday/NL_nl.ics) .
 
+= How do I set different colours and text size for the dates, the summary, and the details? =
+
+There is no setting for the color or font of parts in this plugin.
+My philosophy is that layout and code/content should be separated as much as possible.
+Furthermore, the plugin should seamlessly fit the style of the website and be fully customizable via CSS
+
+So for color and font, the settings of the theme are used and are then applied via CSS.
+But you can give each element within the plugin its own style (such as color and font size) from the theme via CSS.
+
+If you know your theme css well and it contains classes you want to use on these fields you can add those class-names in
+the Advanced settings: "SUFFIX GROUP CLASS:", "SUFFIX EVENT START CLASS:" and "SUFFIX EVENT DETAILS CLASS:"
+
+Otherwise you can add a block of additional CSS (or extra css or user css or something like that), which is possible with most themes.   
+IMPORTANT:   
+In order to target the CSS very specifically to the simple-ical-block, it is best to enter something unique in the settings of the block/widget under Advanced in "HTML ANCHOR", for example “Simple-ical-Block-1” the code translated into a high-level ID of the block.
+With the next block of additional CSS you can make the Dates red and 24 px, the Summary blue and 16 px,
+and the Details green with a gray background.
+
+```
+/*additional CSS for Simple-ical-Block-1 */
+#Simple-ical-Block-1 .ical-date {
+color: #ff0000;
+font-size: 24px;
+}
+#Simple-ical-Block-1 .ical_summary {
+color: #0000ff;
+font-size: 16px;
+}
+#Simple-ical-Block-1 .ical_details {
+color: #00ff00;
+background-color: gray;
+font-size: 16px;
+}
+/*end additional CSS for Simple-ical-Block-1 */
+```
+
+
 == Documentation ==
 
 * Gets calendar events via iCal url or google calendar ID

--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ This project is licensed under the [GNU GPL](https://www.gnu.org/licenses/gpl-3.
 
 == Changelog ==
 * 2.2.0 after an issue of gonzob (@gonzob) in WP support forum: 'Bug with repeating events
-' improved handling of EXDATE so that also the first event of a recurrent set can be excluded.
+' improved handling of EXDATE so that also the first event of a recurrent set can be excluded.   
+Parse Recurrence-ID to support changes in individual recurrent events in Google Calendar. Remove _ chars from UID.
 * 2.1.5 tested with joomla 5 added compatibility to 5.0.99
 * 2.1.4 After a feature request of achimmm (in github on Joomla module) added optional placeholder HTML output when no upcoming events are avalable. Also added optional output after the events list (when upcoming events are available).
 * 2.1.3 In response to a support issue of (@marijnvr) (on WP plugin). New lay-out for block with first date line on a higer level li. 'Start with summary' toggle-setting changed in 'layout' select-setting with options 'Startdate higher level', 'Start with summary', 'Old style'.   

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Theoretically this could als happen with recurrent events in the same timezone w
 Test results and comparison with Google and Outlook calendar [with the wordpress plugin](https://wordpress.org/plugins/simple-google-icalendar-widget/) have been uploaded as DayLightSavingTime test.xlsx.
   
 === From the ical specifications ===
+
 ~~~
 see http://www.ietf.org/rfc/rfc5545.txt for specification of te ical format,
 or https://icalendar.org/iCalendar-RFC-5545/

--- a/README.md
+++ b/README.md
@@ -113,36 +113,34 @@ There is no setting for the color or font of parts in this plugin.
 My philosophy is that layout and code/content should be separated as much as possible.
 Furthermore, the plugin should seamlessly fit the style of the website and be fully customizable via CSS
 
-So for color and font, the settings of the theme are used and are then applied via CSS.
+So for color and font, the settings of the template are used and are then applied via CSS.
 But you can give each element within the plugin its own style (such as color and font size) from the theme via CSS.
 
-If you know your theme css well and it contains classes you want to use on these fields you can add those class-names in
-the Advanced settings: "SUFFIX GROUP CLASS:", "SUFFIX EVENT START CLASS:" and "SUFFIX EVENT DETAILS CLASS:"
+If you know your template css well and it contains classes you want to use on these fields you can add those class-names in
+the Settings Tab Advanced : &#34;SUFFIX GROUP CLASS:&#34;, &#34;SUFFIX EVENT START CLASS:&#34; and &#34;SUFFIX EVENT DETAILS CLASS:&#34;
 
-Otherwise you can add a block of additional CSS (or extra css or user css or something like that), which is possible with most themes.   
+Otherwise you can add a block of additional CSS (or extra css or user css or something like that), which is possible with most templates.   
 IMPORTANT:   
-In order to target the CSS very specifically to the simple-ical-block, it is best to enter something unique in the settings of the block/widget under Advanced in "HTML ANCHOR", for example “Simple-ical-Block-1” the code translated into a high-level ID of the block.
+In order to target the CSS very specifically to the simple-ical-block, it is best to enter something unique in the settings of the module Tab Advanced in &#34;HTML ANCHOR&#34;, for example &#39;Simple-ical-Block-1&#39; the code translated into a high-level ID of the module.
 With the next block of additional CSS you can make the Dates red and 24 px, the Summary blue and 16 px,
 and the Details green with a gray background.
 
-```
+~~~
 /*additional CSS for Simple-ical-Block-1 */
-#Simple-ical-Block-1 .ical-date {
+&#35;Simple-ical-Block-1 .ical-date {
 color: #ff0000;
 font-size: 24px;
 }
-#Simple-ical-Block-1 .ical_summary {
+&#35;Simple-ical-Block-1 .ical_summary {
 color: #0000ff;
 font-size: 16px;
 }
-#Simple-ical-Block-1 .ical_details {
+&#35;Simple-ical-Block-1 .ical_details {
 color: #00ff00;
 background-color: gray;
-font-size: 16px;
 }
 /*end additional CSS for Simple-ical-Block-1 */
-```
-
+~~~
 
 == Documentation ==
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Check if you can download the ics file you have designated in the block with a b
 * End of repeating by COUNT or UNTIL
 * By day month, monthday or setpos (BYDAY, BYMONTH, BYMONTHDAY, BYSETPOS) no other by...   
   (not parsed: BYWEEKNO, BYYEARDAY, BYHOUR, BYMINUTE, RDATE)
-* Exclude events on EXDATE from repeat (after evaluating BYSETPOS)
+* Exclude events on EXDATE from recurrence set (after evaluating BYSETPOS)
 * Respects Timezone and Day Light Saving time. Build and tested with Iana timezones as used in php, Google, and Apple now also tested with Microsoft timezones and unknown timezones. For unknown timezone-names using the default timezone of te site  (probably the local timezone set in Joomla administration).  
 
 === Recurrent events, Timezone,  Daylight Saving Time ===
@@ -139,7 +139,8 @@ Test results and comparison with Google and Outlook calendar [with the wordpress
   
 === From the ical specifications ===
 ~~~
-see http://www.ietf.org/rfc/rfc5545.txt for specification of te ical format.
+see http://www.ietf.org/rfc/rfc5545.txt for specification of te ical format,
+or https://icalendar.org/iCalendar-RFC-5545/
 (see 3.3.10. [Page 38] Recurrence Rule in specification
   .____________._________.________._________.________.
   |            |DAILY    |WEEKLY  |MONTHLY  |YEARLY  |
@@ -172,6 +173,8 @@ This project is licensed under the [GNU GPL](https://www.gnu.org/licenses/gpl-3.
 * works with Joomla 4 or higher.
 
 == Changelog ==
+* 2.2.0 after an issue of gonzob (@gonzob) in WP support forum: 'Bug with repeating events
+' improved handling of EXDATE so that also the first event of a recurrent set can be excluded.
 * 2.1.5 tested with joomla 5 added compatibility to 5.0.99
 * 2.1.4 After a feature request of achimmm (in github on Joomla module) added optional placeholder HTML output when no upcoming events are avalable. Also added optional output after the events list (when upcoming events are available).
 * 2.1.3 In response to a support issue of (@marijnvr) (on WP plugin). New lay-out for block with first date line on a higer level li. 'Start with summary' toggle-setting changed in 'layout' select-setting with options 'Startdate higher level', 'Start with summary', 'Old style'.   

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ This project is licensed under the [GNU GPL](https://www.gnu.org/licenses/gpl-3.
 == Changelog ==
 * 2.2.0 after an issue of gonzob (@gonzob) in WP support forum: 'Bug with repeating events
 ' improved handling of EXDATE so that also the first event of a recurrent set can be excluded.   
-Parse Recurrence-ID to support changes in individual recurrent events in Google Calendar. Remove _ chars from UID.
+Basic parse Recurrence-ID (only one Recurrence-ID event to replace one occurrence of the recurrent set) to support changes in individual recurrent events in Google Calendar. Remove _ chars from UID.
 * 2.1.5 tested with joomla 5 added compatibility to 5.0.99
 * 2.1.4 After a feature request of achimmm (in github on Joomla module) added optional placeholder HTML output when no upcoming events are avalable. Also added optional output after the events list (when upcoming events are available).
 * 2.1.3 In response to a support issue of (@marijnvr) (on WP plugin). New lay-out for block with first date line on a higer level li. 'Start with summary' toggle-setting changed in 'layout' select-setting with options 'Startdate higher level', 'Start with summary', 'Old style'.   

--- a/mod_simple_ical_block.xml
+++ b/mod_simple_ical_block.xml
@@ -6,13 +6,13 @@
     	</include>
   	</compatibility>
 	<name>Simple iCal Block</name>
-	<creationDate>09-12-2023</creationDate>	
+	<creationDate>07-01-2024</creationDate>	
 	<author>A.H.C. Waasdorp</author>
 	<copyright>Copyright (C) 2022 - 2024 A.H.C. Waasdorp, All rights reserved.</copyright>
 	<license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
 	<authorEmail>contact@waasdorpsoekhan.nl</authorEmail>
 	<authorUrl>http://www.waasdorpsoekhan.nl</authorUrl>
-	<version>2.1.5</version>
+	<version>2.2.0</version>
 	<description><![CDATA[<div class="sib-info" style="color: #3f48cc;"><p><img class="sib-img" src="../modules/mod_simple_ical_block/assets/simpleicalicon128x128.svg" style="display: inline-block; width: 2em; height:auto; margin-right: 0.5em;"/>Simple iCal Calendar Events Block</p></div>
 	]]></description>
 	<namespace path="src">WaasdorpSoekhan\Module\Simpleicalblock</namespace>

--- a/src/IcsParser.php
+++ b/src/IcsParser.php
@@ -26,7 +26,8 @@
  *   Combined getFutureEvents and Limit array. usort eventsortcomparer now on start, end, cal_ord and with arithmic subtraction because all are integers.
  *   Parse event DURATION; (only) When DTEND is empty: determine end from start plus duration, when duration is empty and start is DATE start plus one day, else = start  
  *   Parse event BYSETPOS;  Parse WKST (default MO) 
- * 2.1.1 Solved Warning: Array to string conversion in .../Transport/Curl.php on line 183 that occured after using php 8.  
+ * 2.1.1 Solved Warning: Array to string conversion in .../Transport/Curl.php on line 183 that occured after using php 8.
+ * 2.2.0 improved handling of EXDATE so that also the first event of a recurrent set can be excluded.  
  */
 namespace WaasdorpSoekhan\Module\Simpleicalblock\Site;
 // no direct access

--- a/src/IcsParser.php
+++ b/src/IcsParser.php
@@ -826,7 +826,15 @@ END:VCALENDAR';
                             $eventObj->exdate[] = $this->parseIcsDateTime($value, $tzid);
                         }
                         break;
-                }
+/*                         not implemented yet
+                                            case "RDATE":
+                                                $dtl = explode(",", $value);
+                                                foreach ($dtl as $value) {
+                                                    $eventObj->rdate[] = $this->parseIcsPeriodOrDateTime($value, $tzid);
+                                                }
+                                                break;
+                        PERIOD = period-explicit OR period-start; period-explicit = date-time "/" date-time;  period-start = date-time "/" dur-value
+ */                }
             }else { // count($list) <= 1
                 if (strlen($l) > 1) {
                     $desc = str_replace(array('\;', '\,', '\r\n','\n', '\r'), array(';', ',', "\n","\n","\n"), substr($l,1));

--- a/src/IcsParser.php
+++ b/src/IcsParser.php
@@ -329,7 +329,9 @@ END:VCALENDAR';
                 $e = $this->parseVevent($eventStr);
                 $e->cal_class = $cal_class;
                 $e->cal_ord = $cal_ord;
-                $this->events[] = $e;
+                if (empty($e->exdate) || !in_array($e->start, $e->exdate)) {
+                    $this->events[] = $e;
+                }
                 // Recurring event?
                 if (isset($e->rrule) && $e->rrule !== '') {
                     /* Recurring event, parse RRULE in associative array add appropriate duplicate events
@@ -583,7 +585,7 @@ END:VCALENDAR';
                                             ($fmdayok || $expand)
                                             && ($count == 0 || $i < $count)
                                             && $newstart->getTimestamp() <= $until
-                                            && !(!empty($e->exdate) && in_array($newstart->getTimestamp(), $e->exdate))
+                                            && (empty($e->exdate) || !in_array($newstart->getTimestamp(), $e->exdate))
                                             && $newstart> $edtstart) { // count events after dtstart
                                                 if ($newstart->getTimestamp() > $nowstart
                                                     ) { // copy only events after now
@@ -934,7 +936,7 @@ END:VCALENDAR';
                 $http = new Http(['headers' => ['Accept-Encoding' => '']]); //accepts known encoding and decodes.
                 try {
                     $httpResponse =  $http->get($url);
-                } catch(\Exception $e) {
+                } catch(\Exception $exc) {
                     continue ;
                 }
                 if (200 != $httpResponse->code) {
@@ -944,7 +946,7 @@ END:VCALENDAR';
                         if (200 != $httpResponse->code) {
                             continue ;
 	                    }
-                    } catch(\Exception $e) {
+                    } catch(\Exception $exc) {
                         continue ;
                     }
                 }
@@ -953,7 +955,7 @@ END:VCALENDAR';
            
             try {
                 $this->parse($httpBody,  $cal_class, $cal_ord );
-            } catch(\Exception $e) {
+            } catch(\Exception $exc) {
                 continue ;
             }
         } // end foreach

--- a/update/mod_simple_ical_block-update.xml
+++ b/update/mod_simple_ical_block-update.xml
@@ -5,6 +5,46 @@
 		<description>Simple iCal Block Module Update</description>
 		<element>mod_simple_ical_block</element>
 		<type>module</type>
+		<version>2.2.0</version>
+		<infourl title="Simple iCal Block Module">https://github.com/bramwaas/joomla_mod_simple_ical_block/blob/main/README.md</infourl>
+		<downloads>
+			<downloadurl type="full" format="zip">https://github.com/bramwaas/joomla_mod_simple_ical_block/archive/refs/tags/v2.2.0.zip</downloadurl>
+		</downloads>
+		<tags>
+			<tag>stable</tag>
+		</tags>
+		<maintainer>A.H.C. Waasdorp</maintainer>
+		<maintainerurl>https://www.waasdorpsoekhan.nl</maintainerurl>
+		<targetplatform name="joomla" version="5.[012345]"/>
+		<php_minimum>7.4.0</php_minimum>
+		<client>site</client>
+		<folder/>
+	</update>
+	<update>
+		<name>Simple iCal Block</name>
+		<description>Simple iCal Block Module Update</description>
+		<element>mod_simple_ical_block</element>
+		<type>module</type>
+		<version>2.2.0</version>
+		<infourl title="Simple iCal Block Module">https://github.com/bramwaas/joomla_mod_simple_ical_block/blob/main/README.md</infourl>
+		<downloads>
+			<downloadurl type="full" format="zip">https://github.com/bramwaas/joomla_mod_simple_ical_block/archive/refs/tags/v2.2.0.zip</downloadurl>
+		</downloads>
+		<tags>
+			<tag>stable</tag>
+		</tags>
+		<maintainer>A.H.C. Waasdorp</maintainer>
+		<maintainerurl>https://www.waasdorpsoekhan.nl</maintainerurl>
+		<targetplatform name="joomla" version="4.[012345]"/>
+		<php_minimum>7.4.0</php_minimum>
+		<client>site</client>
+		<folder/>
+	</update>
+	<update>
+		<name>Simple iCal Block</name>
+		<description>Simple iCal Block Module Update</description>
+		<element>mod_simple_ical_block</element>
+		<type>module</type>
 		<version>2.1.4</version>
 		<infourl title="Simple iCal Block Module">https://github.com/bramwaas/joomla_mod_simple_ical_block/blob/main/README.md</infourl>
 		<downloads>


### PR DESCRIPTION
After an issue of gonzob (@gonzob) in WP support forum: 'Bug with repeating events
' improved handling of EXDATE so that also the first event of a recurrent set can be excluded.   
Basic parse Recurrence-ID (only one Recurrence-ID event to replace one occurrence of the recurrent set) to support changes in individual recurrent events in Google Calendar. Remove _ chars from UID.