### PR TITLE
2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ This project is licensed under the [GNU GPL](https://www.gnu.org/licenses/gpl-3.
 * works with Joomla 4 or higher.
 
 == Changelog ==
+* 2.2.1 20240123 after an issue of black88mx6 in WP support forum: don't display description line when excerpt-length = 0
 * 2.2.0 after an issue of gonzob (@gonzob) in WP support forum: 'Bug with repeating events
 ' improved handling of EXDATE so that also the first event of a recurrent set can be excluded.   
 Basic parse Recurrence-ID (only one Recurrence-ID event to replace one occurrence of the recurrent set) to support changes in individual recurrent events in Google Calendar. Remove _ chars from UID.

--- a/mod_simple_ical_block.xml
+++ b/mod_simple_ical_block.xml
@@ -6,13 +6,13 @@
     	</include>
   	</compatibility>
 	<name>Simple iCal Block</name>
-	<creationDate>07-01-2024</creationDate>	
+	<creationDate>23-01-2024</creationDate>	
 	<author>A.H.C. Waasdorp</author>
 	<copyright>Copyright (C) 2022 - 2024 A.H.C. Waasdorp, All rights reserved.</copyright>
 	<license>https://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
 	<authorEmail>contact@waasdorpsoekhan.nl</authorEmail>
 	<authorUrl>http://www.waasdorpsoekhan.nl</authorUrl>
-	<version>2.2.0</version>
+	<version>2.2.1</version>
 	<description><![CDATA[<div class="sib-info" style="color: #3f48cc;"><p><img class="sib-img" src="../modules/mod_simple_ical_block/assets/simpleicalicon128x128.svg" style="display: inline-block; width: 2em; height:auto; margin-right: 0.5em;"/>Simple iCal Calendar Events Block</p></div>
 	]]></description>
 	<namespace path="src">WaasdorpSoekhan\Module\Simpleicalblock</namespace>

--- a/tmpl/default.php
+++ b/tmpl/default.php
@@ -33,6 +33,7 @@
  *   add htmlspecialchars() to summary, description and location when not 'allowhtml', replacing similar code from IcsParser
  * 2.1.3 use select 'layout' in stead of 'start with summary' to create more lay-out options.
  * 2.1.4 add closing HTML output after eventlist or when no events are available.    
+ * 2.2.1 20240123 don't display description line when excerpt-length = 0
  */
 // no direct access
 defined('_JEXEC') or die ('Restricted access');
@@ -71,7 +72,7 @@ echo '<div id="' . $attributes['anchorId']  .'" data-sib-id="' . $attributes['bl
         $dftsend = $attributes['dateformat_tsend'];
         $dftstart = $attributes['dateformat_tstart'];
         $dftend = $attributes['dateformat_tend'];
-        $excerptlength = $attributes['excerptlength'];
+        $excerptlength = (isset($attributes['excerptlength']) && ' ' < trim($attributes['excerptlength']) ) ? (int) $attributes['excerptlength'] : '' ;
         $sflgi = $attributes['suffix_lgi_class'];
         $sflgia = $attributes['suffix_lgia_class'];
         $data = IcsParser::getData($attributes);


### PR DESCRIPTION
20240123 after an issue of black88mx6 in WP support forum: don't display description line when excerpt-length = 0